### PR TITLE
Add 'bin' folder in run.sh script, in case it doesn't yet exist

### DIFF
--- a/examples/run.sh
+++ b/examples/run.sh
@@ -10,6 +10,7 @@ if [ ! -e "$javaFile" ]; then
 	echo "Cannot find class $1." >&2
 	exit 1
 fi
+mkdir -p ../bin
 javac -cp ../lib/jna/jna.jar:../src/ -d ../bin "$javaFile" || exit 1
 mountPoint="${@: -1}"
 if [ ! -d "$mountPoint" ]; then


### PR DESCRIPTION
This is necessary because the bin folder does not yet exist in a clean git clone.
