### PR TITLE
Introduce an interface for DirectoryFiller to allow testing

### DIFF
--- a/src/main/java/net/fusejna/DirectoryFiller.java
+++ b/src/main/java/net/fusejna/DirectoryFiller.java
@@ -2,12 +2,24 @@ package net.fusejna;
 
 /**
  * Base interface for the transfer-object for the readdir() call.
- * 
- * @author dominik.stadler
  */
 public interface DirectoryFiller
 {
+	/**
+	 * Pass the given files to the FUSE interfaces.
+	 * 
+	 * @param files
+	 *            A list of filenames without directory.
+	 * @return true if the operation succeeds, false if a problem happens when passing any of the files to FUSE.
+	 */
 	public boolean add(Iterable<String> files);
 
+	/**
+	 * Pass the given files to the FUSE interfaces.
+	 * 
+	 * @param files
+	 *            A vararg-array of filenames without directory.
+	 * @return true if the operation succeeds, false if a problem happens when passing any of the files to FUSE.
+	 */
 	public boolean add(String... files);
 }

--- a/src/main/java/net/fusejna/DirectoryFiller.java
+++ b/src/main/java/net/fusejna/DirectoryFiller.java
@@ -1,68 +1,13 @@
 package net.fusejna;
 
-import java.io.File;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-
-import net.fusejna.types.TypeOff;
-
-import com.sun.jna.Function;
-import com.sun.jna.Pointer;
-
-public final class DirectoryFiller
+/**
+ * Base interface for the transfer-object for the readdir() call.
+ * 
+ * @author dominik.stadler
+ */
+public interface DirectoryFiller
 {
-	private static final String currentDirectory = ".";
-	private static final String parentDirectory = "..";
-	private final Pointer buf;
-	private final Function nativeFunction;
-	private final Set<String> addedFiles = new HashSet<String>();
+	public boolean add(Iterable<String> files);
 
-	DirectoryFiller(final Pointer buf, final Function nativeFunction)
-	{
-		this.buf = buf;
-		this.nativeFunction = nativeFunction;
-		add(currentDirectory, parentDirectory);
-	}
-
-	public final boolean add(final Iterable<String> files)
-	{
-		int result;
-		for (String file : files) {
-			if (file == null) {
-				continue;
-			}
-			if (file.contains(File.separator)) {
-				file = new File(file).getName(); // Keep only the name component
-			}
-			if (addedFiles.add(file)) {
-				final Object[] args = { buf, file, null, new TypeOff(0L) };
-				result = nativeFunction.invokeInt(args);
-				if (result != 0) {
-					return false;
-				}
-			}
-		}
-		return true;
-	}
-
-	public final boolean add(final String... files)
-	{
-		return add(Arrays.asList(files));
-	}
-
-	@Override
-	public String toString()
-	{
-		final StringBuilder output = new StringBuilder();
-		int count = 0;
-		for (final String file : addedFiles) {
-			output.append(file);
-			if (count < addedFiles.size() - 1) {
-				output.append(", ");
-			}
-			count++;
-		}
-		return output.toString();
-	}
+	public boolean add(String... files);
 }

--- a/src/main/java/net/fusejna/DirectoryFillerImpl.java
+++ b/src/main/java/net/fusejna/DirectoryFillerImpl.java
@@ -10,6 +10,9 @@ import net.fusejna.types.TypeOff;
 import com.sun.jna.Function;
 import com.sun.jna.Pointer;
 
+/**
+ * A class which provides functionality to pass filenames back to FUSE as part of a readdir() call.
+ */
 public final class DirectoryFillerImpl implements DirectoryFiller
 {
 	private static final String currentDirectory = ".";
@@ -25,9 +28,8 @@ public final class DirectoryFillerImpl implements DirectoryFiller
 		add(currentDirectory, parentDirectory);
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * @see net.fusejna.DirectoryFillerInterface#add(java.lang.Iterable)
+	/**
+	 * {@inheritDoc}
 	 */
 	@Override
 	public final boolean add(final Iterable<String> files)
@@ -51,9 +53,8 @@ public final class DirectoryFillerImpl implements DirectoryFiller
 		return true;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * @see net.fusejna.DirectoryFillerInterface#add(java.lang.String)
+	/**
+	 * {@inheritDoc}
 	 */
 	@Override
 	public final boolean add(final String... files)
@@ -61,9 +62,8 @@ public final class DirectoryFillerImpl implements DirectoryFiller
 		return add(Arrays.asList(files));
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * @see net.fusejna.DirectoryFillerInterface#toString()
+	/**
+	 * {@inheritDoc}
 	 */
 	@Override
 	public String toString()

--- a/src/main/java/net/fusejna/DirectoryFillerImpl.java
+++ b/src/main/java/net/fusejna/DirectoryFillerImpl.java
@@ -1,0 +1,82 @@
+package net.fusejna;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import net.fusejna.types.TypeOff;
+
+import com.sun.jna.Function;
+import com.sun.jna.Pointer;
+
+public final class DirectoryFillerImpl implements DirectoryFiller
+{
+	private static final String currentDirectory = ".";
+	private static final String parentDirectory = "..";
+	private final Pointer buf;
+	private final Function nativeFunction;
+	private final Set<String> addedFiles = new HashSet<String>();
+
+	DirectoryFillerImpl(final Pointer buf, final Function nativeFunction)
+	{
+		this.buf = buf;
+		this.nativeFunction = nativeFunction;
+		add(currentDirectory, parentDirectory);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see net.fusejna.DirectoryFillerInterface#add(java.lang.Iterable)
+	 */
+	@Override
+	public final boolean add(final Iterable<String> files)
+	{
+		int result;
+		for (String file : files) {
+			if (file == null) {
+				continue;
+			}
+			if (file.contains(File.separator)) {
+				file = new File(file).getName(); // Keep only the name component
+			}
+			if (addedFiles.add(file)) {
+				final Object[] args = { buf, file, null, new TypeOff(0L) };
+				result = nativeFunction.invokeInt(args);
+				if (result != 0) {
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see net.fusejna.DirectoryFillerInterface#add(java.lang.String)
+	 */
+	@Override
+	public final boolean add(final String... files)
+	{
+		return add(Arrays.asList(files));
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see net.fusejna.DirectoryFillerInterface#toString()
+	 */
+	@Override
+	public String toString()
+	{
+		final StringBuilder output = new StringBuilder();
+		int count = 0;
+		for (final String file : addedFiles) {
+			output.append(file);
+			if (count < addedFiles.size() - 1) {
+				output.append(", ");
+			}
+			count++;
+		}
+		return output.toString();
+	}
+}

--- a/src/main/java/net/fusejna/FuseFilesystem.java
+++ b/src/main/java/net/fusejna/FuseFilesystem.java
@@ -12,16 +12,9 @@ import net.fusejna.StructFuseFileInfo.FileInfoWrapper;
 import net.fusejna.StructStat.StatWrapper;
 import net.fusejna.StructStatvfs.StatvfsWrapper;
 import net.fusejna.StructTimeBuffer.TimeBufferWrapper;
-import net.fusejna.types.TypeDev;
-import net.fusejna.types.TypeGid;
-import net.fusejna.types.TypeMode;
+import net.fusejna.types.*;
 import net.fusejna.types.TypeMode.ModeWrapper;
 import net.fusejna.types.TypeMode.NodeType;
-import net.fusejna.types.TypeOff;
-import net.fusejna.types.TypePid;
-import net.fusejna.types.TypeSize;
-import net.fusejna.types.TypeUInt32;
-import net.fusejna.types.TypeUid;
 
 import com.sun.jna.Function;
 import com.sun.jna.Pointer;
@@ -230,7 +223,7 @@ public abstract class FuseFilesystem
 	final int _readdir(final String path, final Pointer buf, final Pointer fillFunction, final TypeOff offset,
 			final StructFuseFileInfo info)
 	{
-		return readdir(path, new DirectoryFiller(buf, Function.getFunction(fillFunction)));
+		return readdir(path, new DirectoryFillerImpl(buf, Function.getFunction(fillFunction)));
 	}
 
 	@FuseMethod


### PR DESCRIPTION
In JGitFS I tried to unit test some of my code, but failed to create a unit test for the readdir() implementation because DirectoryFiller is an implementation class which cannot be instantiated at all from outside of fuse-jna. 

This patch introduces an interface DirectoryFiller and moves the implementation into an implementation class. This way I can create a dummy implementation for my unit tests. No actual code-change takes place, only moving of actual code into new class.
