### PR TITLE
Incorrect mapping of bitfields in StructFuseFileInfo

### DIFF
--- a/src/main/java/net/fusejna/StructFuseFileInfo.java
+++ b/src/main/java/net/fusejna/StructFuseFileInfo.java
@@ -103,12 +103,9 @@ public class StructFuseFileInfo extends Structure
 		{
 			modified = true;
 
-			if (direct_io)
-			{
+			if (direct_io) {
 				fileinfo.flags_bitfield |= BIT_DIRECT_IO;
-			}
-			else
-			{
+			} else {
 				fileinfo.flags_bitfield &= ~BIT_DIRECT_IO;
 			}
 
@@ -151,6 +148,23 @@ public class StructFuseFileInfo extends Structure
 			return this;
 		}
 
+		public final boolean flockrelease()
+		{
+			return (fileinfo.flags_bitfield & BIT_FLOCKRELEASE) != 0;
+		}
+
+		public final FileInfoWrapper flockrelease(final boolean flockrelease)
+		{
+			modified = true;
+
+			if (flockrelease) {
+				fileinfo.flags_bitfield |= BIT_FLOCKRELEASE;
+			} else {
+				fileinfo.flags_bitfield &= ~BIT_FLOCKRELEASE;
+			}
+			return this;
+		}
+
 		public final boolean flush()
 		{
 			return (fileinfo.flags_bitfield & BIT_FLUSH) != 0;
@@ -160,12 +174,9 @@ public class StructFuseFileInfo extends Structure
 		{
 			modified = true;
 
-			if (flush)
-			{
+			if (flush) {
 				fileinfo.flags_bitfield |= BIT_FLUSH;
-			}
-			else
-			{
+			} else {
 				fileinfo.flags_bitfield &= ~BIT_FLUSH;
 			}
 
@@ -181,12 +192,9 @@ public class StructFuseFileInfo extends Structure
 		{
 			modified = true;
 
-			if (keep_cache)
-			{
+			if (keep_cache) {
 				fileinfo.flags_bitfield |= BIT_KEEP_CACHE;
-			}
-			else
-			{
+			} else {
 				fileinfo.flags_bitfield &= ~BIT_KEEP_CACHE;
 			}
 
@@ -214,34 +222,10 @@ public class StructFuseFileInfo extends Structure
 		{
 			modified = true;
 
-			if (nonseekable)
-			{
+			if (nonseekable) {
 				fileinfo.flags_bitfield |= BIT_NONSEEKABLE;
-			}
-			else
-			{
+			} else {
 				fileinfo.flags_bitfield &= ~BIT_NONSEEKABLE;
-			}
-			return this;
-		}
-
-
-		public final boolean flockrelease()
-		{
-			return (fileinfo.flags_bitfield & BIT_FLOCKRELEASE) != 0;
-		}
-
-		public final FileInfoWrapper flockrelease(final boolean flockrelease)
-		{
-			modified = true;
-
-			if (flockrelease)
-			{
-				fileinfo.flags_bitfield |= BIT_FLOCKRELEASE;
-			}
-			else
-			{
-				fileinfo.flags_bitfield &= ~BIT_FLOCKRELEASE;
 			}
 			return this;
 		}


### PR DESCRIPTION
Certain flags in StructFuseFileInfo were mapped as individual variables when they should have been mapped as bitfields. 

This is a serious bug that results in:
1. Memory beyond the allocated fuse struct being accessed and modified, potentially leading to a buffer overflow exploit.
2. Making it difficult to utilize any of these flags
2. Making it impossible to created file-handle based file systems, as the fh variable comes after this variable.

The source in fuse_common.h is specified as follows:

> unsigned int direct_io : 1;
> unsigned int keep_cache : 1;
> unsigned int flush : 1;
> unsigned int nonseekable : 1;
> unsigned int flock_release : 1;
> unsigned int padding : 27;

This change will fix this issue by making these flags as bitfields. Unfortunately, there isn't a clean way to do this mapping in JNA, so bitmask operations are used on a 32bit integer to accomplish this.
