### PR TITLE
Add eclipse plugin to build.gradle to provide 'gradle eclipse' to regenerate Eclipse project files for adjusted JNA lib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'idea'
+apply plugin: 'eclipse'
 
 repositories {
 	mavenCentral()


### PR DESCRIPTION
Unfortunately the Eclipse .classpath does not seem to be the same on each machine, thus I added the eclipse-plugin to the gradle build file so that calling "gradle eclipse" will regenerate the files with the correct pathes.

In other projects we do not even check in the .classpath/.project/.settings files and simply describe this step as part of "start hacking" in the README...
