### PR TITLE
Remove race condition when reading process output

### DIFF
--- a/src/main/java/net/fusejna/ProcessGobbler.java
+++ b/src/main/java/net/fusejna/ProcessGobbler.java
@@ -63,29 +63,34 @@ final class ProcessGobbler
 
 	int getReturnCode()
 	{
-		join();
-		return returnCode;
-	}
-
-	String getStderr()
-	{
-		join();
-		return stderr.getContents();
-	}
-
-	String getStdout()
-	{
-		join();
-		return stdout.getContents();
-	}
-
-	private void join()
-	{
 		try {
 			returnCode = process.waitFor();
 		}
 		catch (final InterruptedException e) {
 			// Too bad
 		}
+		return returnCode;
+	}
+
+	String getStderr()
+	{
+		try {
+			stderr.join();
+		}
+		catch (final InterruptedException e) {
+			return null;
+		}
+		return stderr.getContents();
+	}
+
+	String getStdout()
+	{
+		try {
+			stdout.join();
+		}
+		catch (final InterruptedException e) {
+			return null;
+		}
+		return stdout.getContents();
 	}
 }


### PR DESCRIPTION
The `getStderr()` and `getStdout()` calls wait for the process to finish but not for the output to be read.  This results in methods returning prematurely with a `null` (about 2% of the time on my machine).

This race condition impacts setting current uid and gid in FuseJna.init() and results in files being owned by root rather than the user.

To reproduce:

```
    public static void main(final String args[]) throws Exception
    {
        int nullCount = 0;
        for (int i = 0; i < 1000; i++) {
            if (new ProcessGobbler("id", "-u").getStdout() == null) {
                nullCount++;
            }
        }
        System.out.println(nullCount);
    }
```
